### PR TITLE
add missing comma in cli.py

### DIFF
--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -76,7 +76,7 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
                                'tx_power', 'tari', 'session',
                                'population', 'mode_identifier',
                                'reconnect', 'tag_filter_mask',
-                               'keepalive_interval'
+                               'keepalive_interval',
                                'impinj_extended_configuration',
                                'impinj_search_mode',
                                'impinj_reports',


### PR DESCRIPTION
Another missing comma, my bad. I have just tested this with an impinj reader and traced the wireshark log to confirm that it is actually working now.